### PR TITLE
New option "maskPlaceholder"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ along with a set of commonly used masks including
 ## Installation
 
 ```
-$ npm install ember-inputmask --save-dev
-$ ember g ember-inputmask
+$ ember install:addon ember-inputmask
 ```
 
 ## Usage
@@ -59,6 +58,10 @@ to you. Either way, both values are accessible and bound to each other, so
 choose whichever one you want.
 
 ### Options
+
+#### maskPlaceholder (default: null)
+
+Override $.inputmask default's [placeholder option](https://github.com/RobinHerbots/jquery.inputmask#placeholder-1)
 
 #### showMaskOnFocus (default: true)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ along with a set of commonly used masks including
 ## Installation
 
 ```
-$ ember install:addon ember-inputmask
+$ ember install ember-inputmask
 ```
 
 ## Usage

--- a/addon/components/credit-card-input.js
+++ b/addon/components/credit-card-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**
@@ -8,7 +7,7 @@ import InputMaskComponent from 'ember-inputmask/components/input-mask';
  *
  * Currently Supports: Visa, MasterCard, Amex, Diners Club, Discover, JCB
  *
- * FUTURE: 
+ * FUTURE:
  *   - Add support for more cards
  *   - Add validation for full card numbers
  */
@@ -35,7 +34,7 @@ export default InputMaskComponent.extend({
   }.observes('mask', 'cardType', 'separator'),
 
   updateCardType: function() {
-    var unmaskedValue = this.get('unmaskedValue') || '', 
+    var unmaskedValue = this.get('unmaskedValue') || '',
         cardType;
 
     if (unmaskedValue.match(/^4/)) {

--- a/addon/components/currency-input.js
+++ b/addon/components/currency-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**

--- a/addon/components/date-input.js
+++ b/addon/components/date-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**

--- a/addon/components/email-input.js
+++ b/addon/components/email-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**

--- a/addon/components/input-mask.js
+++ b/addon/components/input-mask.js
@@ -7,6 +7,8 @@ import Ember from 'ember';
  * using the jquery.inputmask plugin.
  *
  * OPTIONS:
+ *   maskPlaceholder - string
+ *     Override $.inputmask default's placeholder option.
  *   showMaskOnHover - bool=true
  *     Shows a preview of the mask when the field is hovered.
  *   showMaskOnFocus - bool=true
@@ -35,7 +37,7 @@ export default Ember.TextField.extend({
   initializeOptions: function() {
     this.set('options', {});
   }.on('init'),
-  
+
   // Initialize the mask by forcing a
   // call to the updateMask function
   didInsertElement: function() {
@@ -58,7 +60,7 @@ export default Ember.TextField.extend({
     if(this.get('unmaskedValue')) {
       this.$().val(this.get('unmaskedValue'));
     }
-    
+
     // If the mask has changed, we need to refocus the input to show the
     // proper mask preview. Since the caret is not positioned by the focus
     // even, but the click event, we need to trigger a click as well.
@@ -83,6 +85,7 @@ export default Ember.TextField.extend({
     }
 
     this.setProperties({
+      'options.placeholder'    : this.get('maskPlaceholder'),
       'options.showMaskOnFocus': this.get('showMaskOnFocus'),
       'options.showMaskOnHover': this.get('showMaskOnHover'),
       'options.rightAlign':      this.get('rightAlign'),
@@ -91,9 +94,9 @@ export default Ember.TextField.extend({
     });
 
     this.setMask();
-  }.observes('mask', 'showMaskOnFocus', 'showMaskOnHover', 'rightAlign', 'clearIncomplete', 'greedyMask', 'pattern', 'regex'),
+  }.observes('mask', 'maskPlaceholder', 'showMaskOnFocus', 'showMaskOnHover', 'rightAlign', 'clearIncomplete', 'greedyMask', 'pattern', 'regex'),
 
-  // Unmask the value of the field and set the property. 
+  // Unmask the value of the field and set the property.
   setUnmaskedValue: function() {
     this.set('unmaskedValue', this.$().inputmask('unmaskedvalue'));
   }.observes('value'),

--- a/addon/components/number-input.js
+++ b/addon/components/number-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**
@@ -45,7 +44,7 @@ export default InputMaskComponent.extend({
       this.set('mask', 'decimal');
       this.set('options.digits', this.get('decimal'));
     }
-    
+
     this._super();
   }.observes('mask', 'group', 'decimal', 'separator', 'radix', 'groupSize')
 });

--- a/addon/components/phone-number-input.js
+++ b/addon/components/phone-number-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**
@@ -17,7 +16,7 @@ import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 export default InputMaskComponent.extend({
   mask:    '(999) 999-9999',
-  
+
   updateMask: function() {
     if (this.get('extensions')) {
       this.set('mask', '(999) 999-9999[ x 9{1,4}]');

--- a/addon/components/zip-code-input.js
+++ b/addon/components/zip-code-input.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import InputMaskComponent from 'ember-inputmask/components/input-mask';
 
 /**
@@ -18,7 +17,7 @@ export default InputMaskComponent.extend({
   mask:    '99999',
 
   fullCode: false,
-  
+
   updateMask: function() {
     if (this.get('fullCode')) {
       this.set('mask', '99999[-9999]');


### PR DESCRIPTION
Override $.inputmask default's placeholder option.
https://github.com/RobinHerbots/jquery.inputmask#placeholder-1

This was specifically useful when I needed to add date formats that didn't comply with the default date mask $.inputmask provides (d/m/y).

For instance, in the U.S. the date format is (m/d/y). You can apply the mask yourself, but you lose the nice placeholder (mm/dd/yyyy).

```
{{input-mask
	mask="m/d/y"
	maskPlaceholder="mm/dd/yyyy"
	value=dateOfBirth
	unmaskedValue=dateOfBirthRaw
	placeholder="Date of birth"
}}
```