### PR TITLE
Initialize 'pattern' property in input-mask to make it observable by validation addons

### DIFF
--- a/addon/components/input-mask.js
+++ b/addon/components/input-mask.js
@@ -33,6 +33,10 @@ export default Ember.TextField.extend({
   greedyMask:      false,
   debounce:        0,
 
+  // Make this addon to initially set pattern attribute for working out of the box with
+  // Ember addon like ember-cli-html5-validation
+  pattern:         null,
+
   // Strangely enough, if we initialize the options object on the component itself
   // it's shared between all instances of the object. Since we don't want that, and
   // we do want to store options somewhere, we need to initialize an options object

--- a/addon/components/zip-code-input.js
+++ b/addon/components/zip-code-input.js
@@ -22,8 +22,6 @@ export default InputMaskComponent.extend({
   updateMask: function() {
     if (this.get('fullCode')) {
       this.set('mask', '99999[-9999]');
-    } else {
-      this.set('mask', '99999');
     }
 
     this._super();

--- a/blueprints/ember-inputmask/index.js
+++ b/blueprints/ember-inputmask/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     normalizeEntityName: function() {},
     afterInstall: function(options) {
-      return this.addBowerPackageToProject('jquery.inputmask', '3.2.0');
+      return this.addBowerPackageToProject('jquery.inputmask', '3.2.7');
     }
 };

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-inputmask",
   "dependencies": {
-    "ember": "2.3.0",
+    "ember": "2.4.0",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.1",
     "ember-qunit": "0.4.16",

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -8,7 +8,7 @@
 
   <fieldset>
     <legend>SSN input:</legend>
-    {{ssn-input value=ssnValue}}
+    {{ssn-input value=ssnValue pattern='^\d{3}-\d{2}-\d{4}$'}}
   </fieldset>
 
   <fieldset>


### PR DESCRIPTION
@pzuraq I have been using this addon along with [ember-cli-html5-validation](https://github.com/maestrooo/ember-cli-html5-validation) which is also a popular ember validation addon. 2 days back, I updated my ember app to version 2.4.0 and updated this validation dependency too, and it seems like the upgrade broke the out of the box working of these 2 addons together. In this pull request I have tried to add minimum modification to this addon to expose `pattern` property for such addons which monitors it for validations.

This pull request includes: 
* Updated ember version to 2.4.0
* Initialise `pattern` property for input-mask component so that it is available when the child components (those which inherits input-mask) loads.
* Minor cleanup and refactoring

These modifications helped me to use these 2 addons work with each other without any code changes. I hope this will be useful. Also, if you have any suggestions then that will be helpful too.