### PR TITLE
Added compatibility with ember-cli-fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'ember-inputmask',
   included: function(app) {
     this._super.included(app);
-    app.import(app.bowerDirectory + '/jquery.inputmask/dist/min/jquery.inputmask.bundle.min.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      app.import(app.bowerDirectory + '/jquery.inputmask/dist/jquery.inputmask.bundle.min.js');
+    }
   }
 };


### PR DESCRIPTION
Fix error "JQuery is not defined" when start ember-fastboot server