### PR TITLE
Bump Node version and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
   - EMBER_TRY_SCENARIO=default
@@ -21,14 +22,16 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-ic-ajax": "0.2.4",
     "ember-cli-inject-live-reload": "^1.3.1",
-    "ember-cli-qunit": "^1.2.4",
+    "ember-cli-qunit": "^3.1.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "0.5.1",
     "ember-resolver": "2.0.3",
-    "ember-try": "0.2.0",
+    "ember-try": "^0.2.12",
     "ember-watson": "^0.8.0",
     "loader.js": "4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/pzuraq/ember-inputmask",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Chris Garrett",
   "license": "MIT",


### PR DESCRIPTION
Node 0.10 and 0.12 are no longer maintained by the Node team. Ember CLI and many Ember addons have dropped their support, which unfortunately means that our current 0.10/0.12 compatibility is already broken. It's very hard to try to fix and maintain it, and there's no good reason to do so.

This PR also upgrades ember-cli-qunit and ember-try in order to make tests pass on Travis CI.