### PR TITLE
Fix Fastboot compatibility

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,10 +13,12 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  app.import({
-    development: app.bowerDirectory + '/jquery.inputmask/dist/jquery.inputmask.bundle.js',
-    production: app.bowerDirectory + '/jquery.inputmask/dist/min/jquery.inputmask.bundle.min.js'
-  });
+  if (!process.env.EMBER_CLI_FASTBOOT) {
+    app.import({
+      development: app.bowerDirectory + '/jquery.inputmask/dist/jquery.inputmask.bundle.js',
+      production: app.bowerDirectory + '/jquery.inputmask/dist/min/jquery.inputmask.bundle.min.js'
+    });
+  }
 
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import(app.bowerDirectory + '/jquery.inputmask/dist/jquery.inputmask.bundle.min.js');
+      app.import(app.bowerDirectory + '/jquery.inputmask/dist/min/jquery.inputmask.bundle.min.js');
     }
   }
 };


### PR DESCRIPTION
This PR adds an environment check before importing the inputmask bundle in ember-cli-build.js. If the environment is Fastboot, simply skip the import because the bundle is not compatible with Fastboot.

It also fixes an outdated path to the minified version of the plugin bundle file. The path used to be correct in jquery.inputmask 3.1.x, but it changed in 3.2.x.