### PR TITLE
Change phone-number-input to exclude 1s and 0s as first digits

### DIFF
--- a/addon/components/input-mask.js
+++ b/addon/components/input-mask.js
@@ -40,7 +40,7 @@ export default Ember.TextField.extend({
   pattern:         null,
 
   value: 'value',
-  
+
   options: Ember.computed(function() {
     return {};
   }),
@@ -59,6 +59,12 @@ export default Ember.TextField.extend({
   }),
 
   setMask: function() {
+    Inputmask.extendDefinitions({
+      '2': {
+        'validator': '[2-9]'
+      }
+    });
+
     if (!this.element) {
       return;
     }

--- a/addon/components/phone-number-input.js
+++ b/addon/components/phone-number-input.js
@@ -16,11 +16,11 @@ import InputMaskComponent from 'ember-inputmask/components/input-mask';
  */
 
 export default InputMaskComponent.extend({
-  mask:    '(999) 999-9999',
+  mask:    '(299) 999-9999',
 
   updateMask: function() {
     if (this.get('extensions')) {
-      this.set('mask', '(999) 999-9999[ x 9{1,4}]');
+      this.set('mask', '(299) 999-9999[ x 9{1,4}]');
     }
 
     this._super();

--- a/tests/integration/phone-number-input-test.js
+++ b/tests/integration/phone-number-input-test.js
@@ -10,14 +10,14 @@ test('filled-in value', function(assert) {
   this.render(hbs`{{phone-number-input unmaskedValue=unmaskedValue}}`);
   fillIn('input', '12345678901234');
   triggerEvent('input', 'blur');
-  assert.equal(find('input').value, '(123) 456-7890');
-  assert.equal(this.unmaskedValue, 1234567890);
+  assert.equal(find('input').value, '(234) 567-8901');
+  assert.equal(this.unmaskedValue, 2345678901);
 });
 
 test('extensions work', function(assert) {
   this.render(hbs`{{phone-number-input unmaskedValue=unmaskedValue extensions=true}}`);
-  fillIn('input', '1234567890x1234');
+  fillIn('input', '2234567890x1234');
   triggerEvent('input', 'blur');
-  assert.equal(find('input').value, '(123) 456-7890 x 1234');
-  assert.equal(this.unmaskedValue, 12345678901234);
+  assert.equal(find('input').value, '(223) 456-7890 x 1234');
+  assert.equal(this.unmaskedValue, 22345678901234);
 });


### PR DESCRIPTION
This adds a custom Inputmask definition (`2`) to match only digits 2-9, excluding 1s and 0s.  In the US and Canada, a phone number area code cannot begin with either of those numbers.  This is useful if a user attempts to type or paste in a phone number with the country/long distance code (e.g., 1-217-234-7890).  Without this change, they may paste in such a number and not notice it cut off the last digit.  You would end up with (121) 723-4789. This PR fixes that to mask it as (217) 234-7890.