### PR TITLE
Make fastboot transform actually work

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,10 @@ module.exports = {
   options: {
     nodeAssets: {
       inputmask: () => ({
-        vendor: filesToImport.map(file => `dist/inputmask/${file}`),
-        processTree: input => fastbootTransform(input)
+        vendor: {
+          include: filesToImport.map(file => `dist/inputmask/${file}`),
+          processTree: input => fastbootTransform(input)
+        }
       })
     }
   },


### PR DESCRIPTION
This is related to the #39 and #37 

I'm not sure how this worked before, but it does not work anymore. According to ember-cli-node-assets [documentation](https://github.com/dfreeman/ember-cli-node-assets#addons-with-fastboot), `processTree` hook should be nested inside of `vendor`, but currently it's top level and it does not seem to take any effect.

I was getting boot exceptions like "document is not defined" on 0.4.0-beta.4, this makes it go away and works in browser.